### PR TITLE
Need to cast hostname as string

### DIFF
--- a/ecs-single-node/step1_ecs_singlenode_install.py
+++ b/ecs-single-node/step1_ecs_singlenode_install.py
@@ -160,7 +160,7 @@ def hosts_file_func(hostname):
             print "(Adding) Hostname does not Exist: %s" % hostname
             os.remove("/etc/hostname")
             hostname_file=open("/etc/hostname", "wb")
-            hostname_file.write(hostname)
+            hostname_file.write(str(hostname))
             hostname_file.close()
         else:
             print "(Ignoring) Hostname Exists: %s" % hostname_exists


### PR DESCRIPTION
Thank you @ryandotclair.  This Resolves #7.

----
Update step1_ecs_singlenode_install.py

I ran into this error: "ERROR [root:210] must be string or buffer, not list".

I believe this occurs when hostname begins with an IP address. To manually set the hostname to a string, I've updated line 188 to pass a string value into /etc/hostname. This overcame the error and deployed successfully.