### PR TITLE
Missing Shebang

### DIFF
--- a/ecs-single-node/step1_ecs_singlenode_install.py
+++ b/ecs-single-node/step1_ecs_singlenode_install.py
@@ -1,4 +1,4 @@
-!/usr/bin/env python
+#!/usr/bin/env python
 # An installation program for ECS SW 2.0 Single Data node
 import argparse
 import string


### PR DESCRIPTION
Needed ye olde shebang for interpreter, otherwise:

 File "step1_ecs_singlenode_install.py", line 1
    !/usr/bin/env python
    ^
SyntaxError: invalid syntax