### PR TITLE
use fcntl and socket to get primary IP of a given interface

### DIFF
--- a/ecs-single-node/step1_ecs_singlenode_install.py
+++ b/ecs-single-node/step1_ecs_singlenode_install.py
@@ -6,12 +6,17 @@ import subprocess
 import logging
 import logging.config
 import time
-import sys,re
+import sys
+import re
 import shutil
 import getopt
-import os,json
-
+import os
+import json
 import settings
+import socket
+import fcntl
+import struct
+
 
 # Logging Initialization
 logging.config.dictConfig(settings.ECS_SINGLENODE_LOGGING)
@@ -219,8 +224,10 @@ def network_file_func(ethadapter):
 
     try:
 
-        # Get the IP address
-        ip_address = subprocess.check_output(['hostname', '-i']).rstrip('\r\n')
+        # Get the IP address on Linux
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        ip_address = socket.inet_ntoa(fcntl.ioctl(s.fileno(),
+                0x8915, struct.pack('256s', ethadapter[:15]))[20:24])
 
         # Get the hostname
         hostname = subprocess.check_output(['hostname']).rstrip('\r\n')


### PR DESCRIPTION
... not `hostname -i`.

rationale: `hostname -i` is not guaranteed to return only the primary IP if more than one IP maps to the hostname within a given resolv.conf.  the contents of /etc/hosts, for instance, can cause IPv6 addresses to be returned before any dotted quads.

For example, on my redhat 7.0 VM, `hostname -i` returns something like:

fe80::250:56ff:feb1:xxxx%ens192 10.x.x.x 172.x.x.x

When what I really want is the primary interface IP (not an alias) like I'd find in the output of `ip addr show dev ens192 to 0/0`.