### PR TITLE
Feature vdc2

### DIFF
--- a/ecs-multi-node/step1_ecs_multinode_install.py
+++ b/ecs-multi-node/step1_ecs_multinode_install.py
@@ -11,6 +11,7 @@ import socket
 import os
 import time
 import settings
+import re
 
 # Logging Initialization
 logging.config.dictConfig(settings.ECS_SINGLENODE_LOGGING)
@@ -525,7 +526,7 @@ def getAuthToken(ECSNode, User, Password):
             print("Auth Token %s" % searchObject.group(1))
             return searchObject.group(1)
         except Exception as ex:
-            logger.info("Problem reaching authentication server. Retrying shortly.")
+            logger.info("Problem reaching authentication server. Retrying shortly. %s" % (ex.message))
             # logger.info("Attempting to authenticate for {} minutes.".format(i%2))
 
     logger.fatal("Authentication service not yet started.")

--- a/ecs-multi-node/step1_ecs_multinode_install.py
+++ b/ecs-multi-node/step1_ecs_multinode_install.py
@@ -622,7 +622,7 @@ def main():
     directory_files_conf_func()
     set_docker_configuration_func()
     execute_docker_func(docker_image_name)
-    # modify_container_conf_func()
+    modify_container_conf_func()
     getAuthToken(ip_address,"root","ChangeMe")
     logger.info(
         "Step 1 Completed.  Navigate to the administrator website that is available from any of the ECS data nodes. \

--- a/ecs-multi-node/step2_object_provisioning.py
+++ b/ecs-multi-node/step2_object_provisioning.py
@@ -239,16 +239,17 @@ def getUserSecretKey(ECSNode, username):
 
 def main(argv):
     try:
-        opts, argv = getopt.getopt(argv, '', ["ECSNodes=","Namespace=","ObjectVArray=","ObjectVPool=","UserName=","DataStoreName=","VDCName=","MethodName="])
+        opts, argv = getopt.getopt(argv, '', ["ECSNodes=","Namespace=","ObjectVArray=","ObjectVPool=","UserName=","DataStoreName=","VDCName=","MethodName=","SkipNamespaceProvision"])
     except getopt.GetoptError, e:
         print e
-        print 'ObjectProvisioning.py --ECSNodes=<Coma separated list of datanodes> --Namespace=<namespace> --ObjectVArray=<Object vArray Name> --ObjectVPool=<Object VPool name> --UserName=<user name to be created> --DataStoreName=<Name of the datastore to be created> --VDCName=<Name of the VDC> --MethodName=<Operation to be performed>\n  --MethodName is required only when you need to run a particular step in Object Provisioning.If this option is not provided all the Object Provisioning steps will be run.\n Supported options for --MethodName are:\n UploadLicense \n CreateObjectVarray \n GetVarrayID \n CreateDataStore \n InsertVDC \n CreateObjectVpool \n CreateNamespace \n CreateUserAndSecretKey \n'
+        print 'ObjectProvisioning.py --ECSNodes=<Coma separated list of datanodes> --Namespace=<namespace> --ObjectVArray=<Object vArray Name> --ObjectVPool=<Object VPool name> --UserName=<user name to be created> --DataStoreName=<Name of the datastore to be created> --VDCName=<Name of the VDC> --MethodName=<Operation to be performed> [--SkipNamespaceProvision]\n  --MethodName is required only when you need to run a particular step in Object Provisioning.If this option is not provided all the Object Provisioning steps will be run.\n Supported options for --MethodName are:\n UploadLicense \n CreateObjectVarray \n GetVarrayID \n CreateDataStore \n InsertVDC \n CreateObjectVpool \n CreateNamespace \n CreateUserAndSecretKey \n'
         sys.exit(2)
     ECSNodes=""
     MethodName=""
+    SkipNamespaceProvision = False
     for opt, arg in opts:
         if opt == '-h':
-            print 'ObjectProvisioning.py --ECSNodes=<Coma separated list of datanodes> --Namespace=<namespace> --ObjectVArray=<Object vArray Name> --ObjectVPool=<Object VPool name> --UserName=<user name to be created> --DataStoreName=<Name of the datastore to be created> --VDCName=<Name of the VDC> --MethodName=<Operation to be performed>\n  --MethodName is required only when you need to run a particular step in Object Provisioning.If this option is not provided all the Object Provisioning steps will be run.\n Supported options for --MethodName are:\n UploadLicense \n CreateObjectVarray \n GetVarrayID \n CreateDataStore \n InsertVDC \n CreateObjectVpool \n CreateNamespace \n CreateUserAndSecretKey \n'
+            print 'ObjectProvisioning.py --ECSNodes=<Coma separated list of datanodes> --Namespace=<namespace> --ObjectVArray=<Object vArray Name> --ObjectVPool=<Object VPool name> --UserName=<user name to be created> --DataStoreName=<Name of the datastore to be created> --VDCName=<Name of the VDC> --MethodName=<Operation to be performed> [--SkipNamespaceProvision]\n  --MethodName is required only when you need to run a particular step in Object Provisioning.If this option is not provided all the Object Provisioning steps will be run.\n Supported options for --MethodName are:\n UploadLicense \n CreateObjectVarray \n GetVarrayID \n CreateDataStore \n InsertVDC \n CreateObjectVpool \n CreateNamespace \n CreateUserAndSecretKey \n'
             sys.exit()
         elif opt in ("-ECSNodes", "--ECSNodes"):
             ECSNodes = arg
@@ -268,6 +269,8 @@ def main(argv):
             VDCName = arg
         elif opt in ("-MethodName", "--MethodName"):
             MethodName = arg
+        elif opt in ("-SkipNamespaceProvision", "--SkipNamespaceProvision"):
+            SkipNamespaceProvision = True
 
     global AuthToken
     AuthToken=getAuthToken(ECSNode, "root", "ChangeMe")
@@ -299,7 +302,7 @@ def main(argv):
         time.sleep(20 * 60)
         sys.exit()
     elif MethodName == "InsertVDC":
-        InsertVDC(ECSNode, VDCName)
+        InsertVDCWithRetry(ECSNode, VDCName)
         print("VDCID: %s" %getVDCID(ECSNode, VDCName))
         sys.exit()
     elif MethodName == "CreateObjectVpool":
@@ -336,15 +339,19 @@ def main(argv):
         
         RetryDTStatus(ECSNode)
         InsertVDC(ECSNode, VDCName)
+        RetryDTStatus(ECSNode)
         print("VDCID: %s" %getVDCID(ECSNode, VDCName))
         CreateObjectVpoolWithRetry(ECSNode, ObjectVPool, VDCName)
         print("Data service vPool ID:%s" %getVpoolID(ECSNode))
         ObjectVPoolID = getVpoolID(ECSNode)
-        CreateNamespace(ECSNode, Namespace, ObjectVPoolID)
-        print("Namespace: %s" %getNamespaces(ECSNode))
-        addUser(ECSNode, UserName,  Namespace)
-        addUserSecretKey(ECSNode, UserName)
-        getUserSecretKey(ECSNode, UserName)
+
+        if not SkipNamespaceProvision:
+            CreateNamespace(ECSNode, Namespace, ObjectVPoolID)
+            print("Namespace: %s" %getNamespaces(ECSNode))
+            addUser(ECSNode, UserName,  Namespace)
+            addUserSecretKey(ECSNode, UserName)
+            getUserSecretKey(ECSNode, UserName)
+
         sys.exit()
 
 

--- a/ecs-multi-node/step2_object_provisioning.py
+++ b/ecs-multi-node/step2_object_provisioning.py
@@ -32,14 +32,13 @@ def executeRestAPI(url, method, filter, data, ECSNode,contentType='json',checkOu
     print ("Executing REST API command: %s " % curlCommand)
 #print jsonResult
     if checkOutput:
-        subprocess.call(curlCommand, shell=True)
         jsonResult = subprocess.check_output(curlCommand, shell=True)
         RestOutputDict = {}
         RestOutputDict = json.loads(jsonResult)
         return RestOutputDict
         assert "code" not in jsonResult, "%s %s failed" % (method, url)
     else:
-        res=subprocess.call(curlCommand, shell=True)
+        res=subprocess.check_output(curlCommand, shell=True)
         print res
 
 
@@ -239,17 +238,17 @@ def getUserSecretKey(ECSNode, username):
 
 def main(argv):
     try:
-        opts, argv = getopt.getopt(argv, '', ["ECSNodes=","Namespace=","ObjectVArray=","ObjectVPool=","UserName=","DataStoreName=","VDCName=","MethodName=","SkipNamespaceProvision"])
+        opts, argv = getopt.getopt(argv, '', ["ECSNodes=","Namespace=","ObjectVArray=","ObjectVPool=","UserName=","DataStoreName=","VDCName=","MethodName=","SkipVdcProvision"])
     except getopt.GetoptError, e:
         print e
-        print 'ObjectProvisioning.py --ECSNodes=<Coma separated list of datanodes> --Namespace=<namespace> --ObjectVArray=<Object vArray Name> --ObjectVPool=<Object VPool name> --UserName=<user name to be created> --DataStoreName=<Name of the datastore to be created> --VDCName=<Name of the VDC> --MethodName=<Operation to be performed> [--SkipNamespaceProvision]\n  --MethodName is required only when you need to run a particular step in Object Provisioning.If this option is not provided all the Object Provisioning steps will be run.\n Supported options for --MethodName are:\n UploadLicense \n CreateObjectVarray \n GetVarrayID \n CreateDataStore \n InsertVDC \n CreateObjectVpool \n CreateNamespace \n CreateUserAndSecretKey \n'
+        print 'ObjectProvisioning.py --ECSNodes=<Coma separated list of datanodes> --Namespace=<namespace> --ObjectVArray=<Object vArray Name> --ObjectVPool=<Object VPool name> --UserName=<user name to be created> --DataStoreName=<Name of the datastore to be created> --VDCName=<Name of the VDC> --MethodName=<Operation to be performed> [--SkipVdcProvision]\n  --MethodName is required only when you need to run a particular step in Object Provisioning.If this option is not provided all the Object Provisioning steps will be run.\n Supported options for --MethodName are:\n UploadLicense \n CreateObjectVarray \n GetVarrayID \n CreateDataStore \n InsertVDC \n CreateObjectVpool \n CreateNamespace \n CreateUserAndSecretKey \nUse --SkipVdcProvision for non-primary VDCs\n'
         sys.exit(2)
     ECSNodes=""
     MethodName=""
-    SkipNamespaceProvision = False
+    SkipVdcProvision = False
     for opt, arg in opts:
         if opt == '-h':
-            print 'ObjectProvisioning.py --ECSNodes=<Coma separated list of datanodes> --Namespace=<namespace> --ObjectVArray=<Object vArray Name> --ObjectVPool=<Object VPool name> --UserName=<user name to be created> --DataStoreName=<Name of the datastore to be created> --VDCName=<Name of the VDC> --MethodName=<Operation to be performed> [--SkipNamespaceProvision]\n  --MethodName is required only when you need to run a particular step in Object Provisioning.If this option is not provided all the Object Provisioning steps will be run.\n Supported options for --MethodName are:\n UploadLicense \n CreateObjectVarray \n GetVarrayID \n CreateDataStore \n InsertVDC \n CreateObjectVpool \n CreateNamespace \n CreateUserAndSecretKey \n'
+            print 'ObjectProvisioning.py --ECSNodes=<Coma separated list of datanodes> --Namespace=<namespace> --ObjectVArray=<Object vArray Name> --ObjectVPool=<Object VPool name> --UserName=<user name to be created> --DataStoreName=<Name of the datastore to be created> --VDCName=<Name of the VDC> --MethodName=<Operation to be performed> [--SkipVdcProvision]\n  --MethodName is required only when you need to run a particular step in Object Provisioning.If this option is not provided all the Object Provisioning steps will be run.\n Supported options for --MethodName are:\n UploadLicense \n CreateObjectVarray \n GetVarrayID \n CreateDataStore \n InsertVDC \n CreateObjectVpool \n CreateNamespace \n CreateUserAndSecretKey \nUse --SkipVdcProvision for non-primary VDCs\n'
             sys.exit()
         elif opt in ("-ECSNodes", "--ECSNodes"):
             ECSNodes = arg
@@ -269,19 +268,20 @@ def main(argv):
             VDCName = arg
         elif opt in ("-MethodName", "--MethodName"):
             MethodName = arg
-        elif opt in ("-SkipNamespaceProvision", "--SkipNamespaceProvision"):
-            SkipNamespaceProvision = True
+        elif opt in ("-SkipVdcProvision", "--SkipVdcProvision"):
+            SkipVdcProvision = True
 
     global AuthToken
     AuthToken=getAuthToken(ECSNode, "root", "ChangeMe")
     
     print("ECSNodes: %s" %ECSNode)
-    print("Namespace: %s" %Namespace)
     print("ObjectVArray: %s" %ObjectVArray)
-    print("ObjectVPool: %s" %ObjectVPool)
-    print("UserName: %s" %UserName)
     print("DataStoreName: %s" %DataStoreName)
-    print("VDCName: %s" %VDCName)
+    if not SkipVdcProvision:
+        print("ObjectVPool: %s" %ObjectVPool)
+        print("Namespace: %s" %Namespace)
+        print("UserName: %s" %UserName)
+        print("VDCName: %s" %VDCName)
     print("MethodName: %s" %MethodName)
     
     
@@ -338,14 +338,14 @@ def main(argv):
                 CreateDataStoreOnCommodityNodesWithRetry(node, DataStoreName, ObjectVArrayID)
         
         RetryDTStatus(ECSNode)
-        InsertVDC(ECSNode, VDCName)
-        RetryDTStatus(ECSNode)
-        print("VDCID: %s" %getVDCID(ECSNode, VDCName))
-        CreateObjectVpoolWithRetry(ECSNode, ObjectVPool, VDCName)
-        print("Data service vPool ID:%s" %getVpoolID(ECSNode))
-        ObjectVPoolID = getVpoolID(ECSNode)
 
-        if not SkipNamespaceProvision:
+        if not SkipVdcProvision:
+            InsertVDC(ECSNode, VDCName)
+            RetryDTStatus(ECSNode)
+            print("VDCID: %s" %getVDCID(ECSNode, VDCName))
+            CreateObjectVpoolWithRetry(ECSNode, ObjectVPool, VDCName)
+            print("Data service vPool ID:%s" %getVpoolID(ECSNode))
+            ObjectVPoolID = getVpoolID(ECSNode)
             CreateNamespace(ECSNode, Namespace, ObjectVPoolID)
             print("Namespace: %s" %getNamespaces(ECSNode))
             addUser(ECSNode, UserName,  Namespace)


### PR DESCRIPTION
 * Modify SSM settings to support small storage footprints.  The storage server's allocation pools (L1 and L2) were fighting over blocks since the default settings are geared more to around 1TB of storage.  This had the side-effect of causing DT init failures and the long login time bug (Issue 8) if an audit record couldn't be written to track the login.
 * The step1 script's check for auth service was always failing because of a missing import for the 're' package.
 * Added new "--SkipVdcProvision" option that can be passed to the step2 script.  You can execute this on subsequent VDCs to keep the VDC pristine for adding to your primary VDC (you can't join a VDC to a cloud if it's been initialized with RGs or Namespaces).
 *  Fixed insert VDC process so it will retry if it fails.