### PR TITLE
Fixed target in systemd script

### DIFF
--- a/ecs-multi-node/systemd/docker.ecsmultinode.service
+++ b/ecs-multi-node/systemd/docker.ecsmultinode.service
@@ -9,5 +9,5 @@ ExecStart=/usr/bin/docker start -a ecsmultinode
 ExecStop=/usr/bin/docker stop -t 60 ecsmultinode
 
 [Install]
-WantedBy=local.target
+WantedBy=multi-user.target
 


### PR DESCRIPTION
The systemd script was targeting local.target instead of
multi-user.target.  This was causing the script to not get properly
invoked on boot.