### PR TITLE
fixed license file and path in the documentation

### DIFF
--- a/Documentation/ECS-UI-Web-Interface.md
+++ b/Documentation/ECS-UI-Web-Interface.md
@@ -8,7 +8,7 @@ You cannot add, change, or remove administrative users in this build. Use the de
 > Username: **root**<br/>Password: **ChangeMe**
 
 ## Input License
-Open *Settings*, then *Licensing* and upload the `license.txt` file located in the root of this repo. **The UI will not automatically update the license view in this release.** Navigating away from page and returning will prompt it to update. You may need to try a few times before it updates. Once it does, you should see something like this:
+Open *Settings*, then *Licensing* and upload the `license.xml` file located in the ecs-single-node / ecs-multi-node folder. **The UI will not automatically update the license view in this release.** Navigating away from page and returning will prompt it to update. You may need to try a few times before it updates. Once it does, you should see something like this:
 
 ![Upload License file](https://github.com/EMCECS/ECS-CommunityEdition/blob/master/Documentation/media/input_license.PNG)
 


### PR DESCRIPTION
When I tried to upload the license.txt the server returned an error 500. Which is no suprise, since this file only contains the software license agreement and no ecs licenses. 
However the license.xml from the ecs-single-node folder was accepted.