### PR TITLE
Update step1_ecs_singlenode_install.py

### DIFF
--- a/ecs-single-node/step1_ecs_singlenode_install.py
+++ b/ecs-single-node/step1_ecs_singlenode_install.py
@@ -269,7 +269,7 @@ def prepare_data_disk_func(disks):
             subprocess.call(["mkdir", "-p", "/ecs/{}".format(uuid_name)])
 
             # mount /dev/sdc1 /ecs/uuid-1
-            logger.info("Mount attached /dev{} to /ecs/{} volume.".format(device_name, uuid_name))
+            logger.info("Mount attached {} to /ecs/{} volume.".format(device_name, uuid_name))
             subprocess.call(["mount", device_name, "/ecs/{}".format(uuid_name), "-o", "noatime,seclabel,attr2,inode64,noquota"])
 
             # add entry to fstab if not pre-existing
@@ -280,7 +280,7 @@ def prepare_data_disk_func(disks):
                 logger.info("Data disk already entered in fs table")
             elif p.returncode == 1:
                 with open("/etc/fstab", 'a') as file:
-                    file.write("{} {} xfs rw,noatime,seclabel,attr2,inode64, noquota 0 0".format(device_name, uuid_name) )
+                    file.write("{} /ecs/{} xfs rw,noatime,seclabel,attr2,inode64, noquota 0 0".format(device_name, uuid_name) )
             else:
                 logger.info("Error in checking filesystem table: {}".format(err))
 


### PR DESCRIPTION
we have to recheck the naming conventions !

device_name ist the full devicepath device_name = disk_path + "1"
where uuid_name only contains the relative name and not the absolute path

this resukts in an invalid logger output:

Mount attached /dev/dev/sdb1 to /ecs/uuid-1 volume.

and the generated FStab Entry is wrong.
/dev/sdb1 uuid-1 xfs rw,noatime,seclabel,attr2,inode64, noquota 0 0

[ 1804.971065] systemd-fstab-generator[65807]: Mount point uuid-1 is not a valid path, ignoring.

Also, xisting Entries ARE NOT detected.

my suggestion would be 
file.write("{} /ecs/{} xfs rw,noatime,seclabel,attr2,inode64, noquota 0 0".format(device_name, uuid_name