### PR TITLE
Update step1_ecs_singlenode_install.py to block docker_pull when image loaded

### DIFF
--- a/ecs-single-node/step1_ecs_singlenode_install.py
+++ b/ecs-single-node/step1_ecs_singlenode_install.py
@@ -774,7 +774,7 @@ def main():
     prep_file_func()
     if args.image_file:
         docker_load_image(args.image_file)
-    if not args.no_internet:
+    elif not args.no_internet:
         docker_pull_func(docker_image_name)
     hosts_file_func(args.hostname, ethernet_adapter_name)
     network_file_func(ethernet_adapter_name)


### PR DESCRIPTION
When docker _load_image is specified, the image is also downloded because pull function is run.
 pull is only exluded on no internet
changing to elif will block the pull function when imagefile is loaded