### PR TITLE
fix the argument check

### DIFF
--- a/ecs-single-node/additional_prep.sh
+++ b/ecs-single-node/additional_prep.sh
@@ -20,11 +20,10 @@ function usage {
 }
 
 device=$1
-mount_point=`$MOUNT | $GREP $device | $AWK '{print $3}'`
-
-if [ -z "$device" -o -z "$mount_point" ]; then
+if [ -z "$device" ]; then
     usage
 fi
+mount_point=`$MOUNT | $GREP $device | $AWK '{print $3}'`
 
 # mount file system to create files on it
 $MOUNT | $GREP $device -q


### PR DESCRIPTION
currently, when the script run without argument , it gives 
```
CI-1:~ # ./pre.sh
Usage: /usr/bin/grep [OPTION]... PATTERN [FILE]...
Try '/usr/bin/grep --help' for more information.
usage: ./pre.sh <mounted_device>
```
ideally it shouldnt even grep and check mount_point if `$device` is not set i.e. $1 not passed. with this patch:
```
usage: ./pre.sh <mounted_device>
```