### PR TITLE
Remove seclabel from mount options

### DIFF
--- a/ecs-multi-node/additional_prep.sh
+++ b/ecs-multi-node/additional_prep.sh
@@ -74,7 +74,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # mount again, the file system is now ready
-$MOUNT $device $mount_point -o rw,noatime,seclabel,attr2,inode64,noquota
+$MOUNT $device $mount_point -o rw,noatime,attr2,inode64,noquota
 
 # Add the filesystem to /etc/fstab
-grep "$device" /etc/fstab || echo "$MOUNT $device $mount_point -o rw,noatime,seclabel,attr2,inode64,noquota 0 0" >> /etc/fstab
+grep "$device" /etc/fstab || echo "$MOUNT $device $mount_point -o rw,noatime,attr2,inode64,noquota 0 0" >> /etc/fstab

--- a/ecs-multi-node/step1_ecs_multinode_install.py
+++ b/ecs-multi-node/step1_ecs_multinode_install.py
@@ -294,7 +294,7 @@ def prepare_data_disk_func(disks):
 
             # mount /dev/sdc1 /ecs/uuid-[uuid]
             logger.info("Mount attached {} to /ecs/{} volume.".format(device_name, uuid_name))
-            subprocess.call(["mount", device_name, "/ecs/{}".format(uuid_name), "-o", "noatime,seclabel,attr2,inode64,noquota"])
+            subprocess.call(["mount", device_name, "/ecs/{}".format(uuid_name), "-o", "noatime,attr2,inode64,noquota"])
 
             # add entry to fstab if not pre-existing
             fstab = "/etc/fstab"
@@ -304,7 +304,7 @@ def prepare_data_disk_func(disks):
                 logger.info("Data disk already entered in fs table")
             elif p.returncode == 1:
                 with open("/etc/fstab", 'a') as file:
-                    file.write("{} /ecs/{} xfs rw,noatime,seclabel,attr2,inode64,noquota 0 0\n".format(device_name, uuid_name) )
+                    file.write("{} /ecs/{} xfs rw,noatime,attr2,inode64,noquota 0 0\n".format(device_name, uuid_name) )
             else:
                 logger.info("Error in checking filesystem table: {}".format(err))
 

--- a/ecs-single-node/additional_prep.sh
+++ b/ecs-single-node/additional_prep.sh
@@ -74,7 +74,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # mount again, the file system is now ready
-$MOUNT $device $mount_point -o rw,noatime,seclabel,attr2,inode64,noquota
+$MOUNT $device $mount_point -o rw,noatime,attr2,inode64,noquota
 
 # Add the filesystem to /etc/fstab
-grep "$device" /etc/fstab || echo "$MOUNT $device $mount_point -o rw,noatime,seclabel,attr2,inode64,noquota 0 0" >> /etc/fstab
+grep "$device" /etc/fstab || echo "$MOUNT $device $mount_point -o rw,noatime,attr2,inode64,noquota 0 0" >> /etc/fstab

--- a/ecs-single-node/step1_ecs_singlenode_install.py
+++ b/ecs-single-node/step1_ecs_singlenode_install.py
@@ -283,7 +283,7 @@ def prepare_data_disk_func(disks):
 
             # mount /dev/sdc1 /ecs/uuid-[uuid]
             logger.info("Mount attached {} to /ecs/{} volume.".format(device_name, uuid_name))
-            subprocess.call(["mount", device_name, "/ecs/{}".format(uuid_name), "-o", "noatime,seclabel,attr2,inode64,noquota"])
+            subprocess.call(["mount", device_name, "/ecs/{}".format(uuid_name), "-o", "noatime,attr2,inode64,noquota"])
 
             # add entry to fstab if not pre-existing
             fstab = "/etc/fstab"
@@ -293,7 +293,7 @@ def prepare_data_disk_func(disks):
                 logger.info("Data disk already entered in fs table")
             elif p.returncode == 1:
                 with open("/etc/fstab", 'a') as file:
-                    file.write("{} /ecs/{} xfs rw,noatime,seclabel,attr2,inode64,noquota 0 0\n".format(device_name, uuid_name) )
+                    file.write("{} /ecs/{} xfs rw,noatime,attr2,inode64,noquota 0 0\n".format(device_name, uuid_name) )
             else:
                 logger.info("Error in checking filesystem table: {}".format(err))
 


### PR DESCRIPTION
Hi,

We are using these python scripts on ubuntu. Everything works except for when mounting. The `seclabel` mount option breaks the mount call since we do not run SELinux. The `seclabel` will be added by SELinux if it were running, so removing this from the scripts should not break the build / scripts.

Thanks!