### PR TITLE
[WIP] ECS-CommunityEdition-118

### DIFF
--- a/ui/ansible/clicmd_preflight.yml
+++ b/ui/ansible/clicmd_preflight.yml
@@ -12,4 +12,5 @@
 - name: Installer | Perform preflight check
   hosts: data_node
   roles:
+    - common_collect_facts
     - common_baseline_check

--- a/ui/ansible/roles/common_baseline_install/templates/seeds.j2
+++ b/ui/ansible/roles/common_baseline_install/templates/seeds.j2
@@ -1,5 +1,5 @@
 {%- set comma = joiner(",") -%}
-{%-  set vdc = hostvars[inventory_hostname]['vdc'] -%}
+{%- set vdc = hostvars[inventory_hostname]['vdc'] -%}
 {%- for host in groups.data_node -%}
 {%- if ( (hostvars[host]['vdc'] is defined) and
         (hostvars[host]['vdc'] == vdc) ) -%}

--- a/ui/ansible/roles/common_collect_facts/tasks/main.yml
+++ b/ui/ansible/roles/common_collect_facts/tasks/main.yml
@@ -1,0 +1,13 @@
+- name: "Common | Create custom facts directory"
+  file:
+    path: "/etc/ansible/facts.d"
+    state: "directory"
+
+- name: "Common | Insert data_node.fact file"
+  template:
+    src: data_node.fact.j2
+    dest: /etc/ansible/facts.d/data_node.fact
+    mode: 0755
+
+- name: "Common | Reload facts to pick up new items"
+  setup: ~

--- a/ui/ansible/roles/common_collect_facts/templates/data_node.fact.j2
+++ b/ui/ansible/roles/common_collect_facts/templates/data_node.fact.j2
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+ECS_BLOCK_DEVICES="{%- set comma = joiner(" ") -%}
+{%- for blockdev in ecs_block_devices -%}
+{{ comma() }}{{ blockdev }}
+{%- endfor %}"
+
+total_bytes = 0
+for blockdev in ${ECS_BLOCK_DEVICES}; do
+    total_bytes="$(( ${total_bytes} + $(blockdev --getsize64 ${blockdev}) ))"
+done
+
+echo "{
+    \"ecs_block_devices\": \"${ECS_BLOCK_DEVICES}\",
+    \"ecs_block_size\": \"${total_bytes}\"
+}"

--- a/ui/ansible/roles/common_deploy/templates/ssm.object.properties.j2
+++ b/ui/ansible/roles/common_deploy/templates/ssm.object.properties.j2
@@ -64,8 +64,11 @@ object.bbfmDirMaxEntries=200
 #
 # Proactive reallocation threshold values for levels 1,2 etc.
 # In case if level index is higher than thresholds list length then the latest value is used.
-object.freeBlocksHighWatermarkLevels={{ '100,50' if ansible_memtotal_mb < 65536 else '1000,200' }}
-object.freeBlocksLowWatermarkLevels={{ '0,20' if ansible_memtotal_mb < 65536 else '0,100' }}
+# {#object.freeBlocksHighWatermarkLevels={{ '100,50' if ansible_memtotal_mb < 65536 else '1000,200' }}#}
+# {#object.freeBlocksLowWatermarkLevels={{ '0,20' if ansible_memtotal_mb < 65536 else '0,100' }}#}
+object.freeBlocksHighWatermarkLevels={{ '100,50' if ansible_local.data_node.ecs_block_size < 1000000000000 else '1000,200' }}
+object.freeBlocksLowWatermarkLevels{{ '0,20' if ansible_local.data_node.ecs_block_size < 1000000000000 else '0,100' }}
+object.reallocationRetryTimeoutInSecs=10
 object.reallocationRetryTimeoutInSecs=10
 #set this to false if you want to disable reallocation
 object.ssm.isBlockReallocationEnabled=true


### PR DESCRIPTION
Addresses #118
Adds a custom fact gathering role to the preflight playbook.
Adds custom fact to get total available ECS storage on data nodes.
Updates ssm.object.properties template to base high and low watermarks on available storage rather than memory.
Fixes a couple typos and formatting things in other templates and playbooks.
