### PR TITLE
Resolves #287: Step 1 fails when there is no tty

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -310,6 +310,7 @@ o ""
 v "Creating shell shims in ${HOME}/bin for CLI commands"
 p Installing CLI shims
 symlink_scripts
+update_path_in_bashrc
 
 
 ### Override nameservers provided by DHCP if -o was given.

--- a/bootstrap_plugins/plugin-defaults.plugin.sh
+++ b/bootstrap_plugins/plugin-defaults.plugin.sh
@@ -23,3 +23,10 @@ symlink_scripts() {
         ln -s "${root}/ui/run.sh" "${HOME}/bin/$l" 2>/dev/null
     done
 }
+
+unset update_path_in_bashrc
+update_path_in_bashrc() {
+    log "sed error is OK here if the proxy config file does not yet exist."
+    sudo sed -i -e '/PATH/d' $HOME/.bashrc
+    echo 'export PATH=$PATH:$HOME/.local/bin:$HOME/bin' >> $HOME/.bashrc
+}

--- a/ui/libexec/console.sh
+++ b/ui/libexec/console.sh
@@ -9,6 +9,24 @@
 # limited to the terms and conditions of the License Agreement under which
 # it is provided by or on behalf of EMC.
 
+### TTY Detection
+
+export IS_TTY=false
+export IS_PIPE=false
+export IS_REDIRECTION=false
+
+if [[ -t 1 ]]; then
+    export IS_TTY=true
+fi
+
+if [[ -p /dev/stdout ]]; then
+    export IS_PIPE=true
+fi
+
+if [[ ! -t 1 && ! -p /dev/stdout ]]; then
+    export IS_REDIRECTION=true
+fi
+
 ### Logging and console output helpers
 
 quiet_flag=false

--- a/ui/run.sh
+++ b/ui/run.sh
@@ -35,8 +35,17 @@ fi
 run() {
     run="${1}"
     shift
-    sudo docker run --rm -it --privileged --net=host ${default_mount_opts[@]} ${image_release} ${run} ${@}
+
+    local _interactive=''
+    if ${IS_TTY}; then
+        _interactive='-it'
+    fi
+
+    sudo docker run --rm ${_interactive} --privileged --net=host \
+            ${default_mount_opts[@]} ${image_release} \
+            ${run} ${@}
     rc=$?
+
     o ""
     return ${rc}
 }

--- a/ui/run.sh
+++ b/ui/run.sh
@@ -38,10 +38,10 @@ run() {
 
     local _interactive=''
     if ${IS_TTY}; then
-        _interactive='-it'
+        _interactive='-t'
     fi
 
-    sudo docker run --rm ${_interactive} --privileged --net=host \
+    sudo docker run --rm -i ${_interactive} --privileged --net=host \
             ${default_mount_opts[@]} ${image_release} \
             ${run} ${@}
     rc=$?


### PR DESCRIPTION
Added basic POSIX-style tty/pipeline/redirection detection to console.sh.  
Now it's possible to test against IS_TTY, IS_PIPE, and IS_REDIRECTION when 
deciding what to do with the terminal.