### PR TITLE
revert to ECS CE 3.0.0.1 (3.0.0 HF1)

### DIFF
--- a/ui/etc/config.yml
+++ b/ui/etc/config.yml
@@ -31,7 +31,7 @@ ui:
   ffx_sem: /opt/ffx.sem
 product:
   name: ECS
-  version: 3.0.0.2
+  version: 3.0.0.1
   vendor: Dell EMC
   flavor: Community Edition
   slogan: Free and Frictionless

--- a/ui/etc/release.conf
+++ b/ui/etc/release.conf
@@ -8,7 +8,7 @@
 # it is provided by or on behalf of EMC.
 
 release_name="ECS Community Edition"
-release_version="3.0.0.2"
+release_version="3.0.0.1"
 release_product="ECS Software"
 release_artifact="emccorp/ecs-software-3.0.0"
 release_tag="latest"


### PR DESCRIPTION
The 3.0.0.2 image is having issues.  This PR also reopens #305 (for tracking).