### PR TITLE
Change the way ecs-install image is pushed to Dockerhub

### DIFF
--- a/ui/build_image.sh
+++ b/ui/build_image.sh
@@ -43,6 +43,8 @@ elif ! [ -z "$1" ] && [ "$1" == "--update-mirror" ]; then
     fi
 fi
 
+build_push=false
+
 o "Building image ${image_name}"
 o "Build context is: ${context}"
 
@@ -68,7 +70,8 @@ BuildPush="-var BuildPush=${latest_image_path}"
 case $context in
 
     release)
-        BuildPush="--push ${BuildPush}"
+        # BuildPush="--push ${BuildPush}"
+        build_push=true
         o "I will push a release image to the registry after build"
     ;;
 
@@ -105,9 +108,13 @@ Rockerfile="-f ui/resources/docker/Rockerfile"
 o "UI artifact is: ${ui_artifact}"
 # Currently using the Ansible apk
 # o "Ansible artifact is: ${ansible_artifact}"
-sudo /usr/local/bin/rocker build $Context $Version $Artifacts $FromImage $BuildPush $Rockerfile $HTTPProxy $PipProxy . || img_build_fail
+sudo /usr/local/bin/rocker build $Context $Version $Artifacts $FromImage $Rockerfile $HTTPProxy $PipProxy . || img_build_fail
 
 o "Tagging ${full_image_path} -> ${image_release}"
 sudo docker tag "${full_image_path}" "${image_release}" || img_pull_fail
+
+if ${build_push}; then
+    sudo docker push "${image_release}"
+fi
 
 exit 0

--- a/ui/resources/docker/Rockerfile
+++ b/ui/resources/docker/Rockerfile
@@ -85,4 +85,4 @@ VOLUME [ "/opt", "/usr/local", "/var/log", "/root", "/etc" ]
 LABEL VERSION={{ .Version }}
 ENV VERSION={{ .Version }}
 TAG {{ .Version }}
-PUSH {{ .BuildPush }}
+# PUSH {{ .BuildPush }}


### PR DESCRIPTION
Rocker doesn't like to push to authenticated Dockerhub repos.  Use `docker push` instead.