### PR TITLE
CM config tuning to stop restart cycle

### DIFF
--- a/patches/3.2.0.1/Dockerfile
+++ b/patches/3.2.0.1/Dockerfile
@@ -28,3 +28,7 @@ RUN f=/opt/storageos/conf/cm.object.properties; grep -q 'MustHaveEnoughResources
 # Allow allocation of different blocks of a chunk to be stored on the same partition
 RUN f=/opt/storageos/conf/ssm-cf-conf.xml; grep -q '<config:boolean name="allowAllocationOnIgnoredPartitions" value="true" description="If set to true, different blocks in one chunk may be allocated on the same partition"/>' $f || sed -i 's#<config:boolean name="allowAllocationOnIgnoredPartitions" value="false" description="If set to true, different blocks in one chunk may be allocated on the same partition"/>#<config:boolean name="allowAllocationOnIgnoredPartitions" value="true" description="If set to true, different blocks in one chunk may be allocated on the same partition"/>#g' /opt/storageos/conf/ssm-cf-conf.xml $f
 
+# Tune CM 
+RUN f=/opt/storageos/conf/cm-conf.xml; grep -q '<prop key="object.BPlusTreeReaderOnHeapCacheV2MemoryCoreSize">419430400</prop>' $f || sed -i 's#<prop key="object.BPlusTreeReaderOnHeapCacheV2MemoryCoreSize">419430400</prop>#<prop key="object.BPlusTreeReaderOnHeapCacheV2MemoryCoreSize">52428800</prop>#g'
+
+52428800

--- a/patches/3.2.0.1/Dockerfile
+++ b/patches/3.2.0.1/Dockerfile
@@ -27,8 +27,3 @@ RUN f=/opt/storageos/conf/cm.object.properties; grep -q 'MustHaveEnoughResources
 
 # Allow allocation of different blocks of a chunk to be stored on the same partition
 RUN f=/opt/storageos/conf/ssm-cf-conf.xml; grep -q '<config:boolean name="allowAllocationOnIgnoredPartitions" value="true" description="If set to true, different blocks in one chunk may be allocated on the same partition"/>' $f || sed -i 's#<config:boolean name="allowAllocationOnIgnoredPartitions" value="false" description="If set to true, different blocks in one chunk may be allocated on the same partition"/>#<config:boolean name="allowAllocationOnIgnoredPartitions" value="true" description="If set to true, different blocks in one chunk may be allocated on the same partition"/>#g' /opt/storageos/conf/ssm-cf-conf.xml $f
-
-# Tune CM 
-RUN f=/opt/storageos/conf/cm-conf.xml; grep -q '<prop key="object.BPlusTreeReaderOnHeapCacheV2MemoryCoreSize">419430400</prop>' $f || sed -i 's#<prop key="object.BPlusTreeReaderOnHeapCacheV2MemoryCoreSize">419430400</prop>#<prop key="object.BPlusTreeReaderOnHeapCacheV2MemoryCoreSize">52428800</prop>#g'
-
-52428800

--- a/ui/ansible/roles/common_deploy/tasks/main.yml
+++ b/ui/ansible/roles/common_deploy/tasks/main.yml
@@ -30,16 +30,10 @@
 #  Installer should support installing a "full" build on systems with 64GB RAM+ #74
 
 - name: Common | Copy configurations out of configuration data container
-  command: docker cp ecs-config:{{item.src}} {{item.dest}}
-  with_items:
-    - dest: /host/ssm.object.properties
-      src: /opt/storageos/conf/ssm.object.properties
-    - dest: /host/common.object.properties
-      src: /opt/storageos/conf/common.object.properties
-    - dest: /host/cm.object.properties
-      src: /opt/storageos/conf/cm.object.properties
+  command: docker cp ecs-config:/opt/storageos/conf/{{item}} /host/{{item}}
+  with_items: "{{config_files}}"
   loop_control:
-    label: "{{item.src}}"
+    label: "{{item}}"
 #    - dest: /host/application.conf
 #      src: /opt/storageos/ecsportal/conf/application.conf
 
@@ -86,8 +80,6 @@
     line: 'object.NumDirectoriesPerCoSForUserDT={{ "128" if ( ansible_memtotal_mb|int > 65536 and ansible_local.data_node.ecs_block_size|int > 1000000000000 and num_data_nodes|int > 3 ) else "32" }}'
 
 ## CM Object Properties
-
-# object.MustHaveEnoughResources
 - name: 'Common | Configure CM Object properties: Disable Minimum Node Count'
   lineinfile:
     dest: /host/cm.object.properties
@@ -95,25 +87,41 @@
     regexp: '^object\.MustHaveEnoughResources=true'
     line: 'object.MustHaveEnoughResources=false'
 
+## CM configuration
+- name: 'Common | Configure CM Read Page Cache: Max'
+  lineinfile:
+    dest: /host/cm-conf.xml
+    state: present
+    regexp: '<prop key="object.BPlusTreeReaderOnHeapCacheV2MemoryMaxSize">536870912</prop>'
+    line: '<prop key="object.BPlusTreeReaderOnHeapCacheV2MemoryMaxSize">52428800</prop>'
+
+- name: 'Common | Configure CM Read Page Cache: Core'
+  lineinfile:
+    dest: /host/cm-conf.xml
+    state: present
+    regexp: '<prop key="object.BPlusTreeReaderOnHeapCacheV2MemoryCoreSize">419430400</prop>'
+    line: '<prop key="object.BPlusTreeReaderOnHeapCacheV2MemoryCoreSize">41943040</prop>'
+
+- name: 'Common | Configure CM DT Write IO: OnHeap Buffers'
+  lineinfile:
+    dest: /host/cm-conf.xml
+    state: present
+    regexp: '<constructor-arg name="initialBufferNumOnHeap" value="10"/>'
+    line: '<constructor-arg name="initialBufferNumOnHeap" value="4"/>'
+
+- name: 'Common | Configure CM Geo Shipping IO: OnHeap Buffers'
+  lineinfile:
+    dest: /host/cm-conf.xml
+    state: present
+    regexp: '<prop key="object.InitialBufferNumOnHeap">50</prop'
+    line: '<prop key="object.InitialBufferNumOnHeap">4</prop>'
+
 ### Then docker cp them into the configuration container
 - name: Common | Merge configurations into configuration data container
-  command: docker cp {{item.src}} ecs-config:{{item.dest}}
-  with_items:
-    - src: /host/ssm.object.properties
-      dest: /opt/storageos/conf/ssm.object.properties
-    - src: /host/common.object.properties
-      dest: /opt/storageos/conf/common.object.properties
-    - src: /host/cm.object.properties
-      dest: /opt/storageos/conf/cm.object.properties
+  command: docker cp /host/{{item}} ecs-config:/opt/storageos/conf/{{item}}
+  with_items: "{{config_files}}"
   loop_control:
-    label: "{{item.dest}}"
-#    - src: /host/application.conf
-#      dest: /opt/storageos/ecsportal/conf/application.conf
-#    - src: postinstall_patch
-#      dest: /etc/cron.hourly/postinstall_patch
-#    - src: setup_python_requests
-#      dest: /etc/cron.hourly/setup_python_requests
-
+    label: "{{item}}"
 
 #- name: debug docker create ecs-storageos
 #  debug:

--- a/ui/ansible/roles/common_deploy/vars/main.yml
+++ b/ui/ansible/roles/common_deploy/vars/main.yml
@@ -1,3 +1,8 @@
 ecs_environnment:
   SS_GENCONFIG: 1
 data_container: ecs-config
+config_files:
+  - ssm.object.properties
+  - common.object.properties
+  - cm.object.properties
+  - cm-conf.xml


### PR DESCRIPTION
CM is running out of memory and restarting, which orphans chunks and causes consumed space to increment.  Tuning those params to stop the restart cycle.