### PR TITLE
Tweaked 3.5.0.0 for 3.5.1.2 build

### DIFF
--- a/patches/3.5.0.0/Dockerfile
+++ b/patches/3.5.0.0/Dockerfile
@@ -1,7 +1,7 @@
 # Fixes to the default 3.5.0.0 reduced image.
 
 # Build on object-reduced image (GA release)
-FROM emcvipr/object:3.5.0.0-120520.8c29468ee8b-reduced
+FROM emcvipr/object:3.5.1.2-121905.b6ac907bc40-reduced
 
 # Fix disk partitioning script
 RUN sed -i '/VMware/ s/$/ \&\& [ ! -e \/data\/is_community_edition ]/' /opt/storageos/bin/storageserver-partition-config.sh \

--- a/patches/3.5.0.0/image.conf
+++ b/patches/3.5.0.0/image.conf
@@ -1,3 +1,3 @@
-BASE_IMAGE="emcvipr/object:3.5.0.0-120520.8c29468ee8b-reduced"
+BASE_IMAGE="emcvipr/object:3.5.1.2-121905.b6ac907bc40-reduced"
 IMAGE_REPO="emccorp/ecs-software-3.5.0"
 IMAGE_VERSION="3.5.0.0"


### PR DESCRIPTION
### This pull request addresses the following referenced issue(s):

1. Updating the 3.5 image to 3.5.1.2

### Overview of changes:

1. Updated the Dockerfile to reference the correct base image for 3.5.1.2
2. Updated the image.conf to use the correct base image for 3.5.1.2

---
@captntuttle
